### PR TITLE
Implement new rules

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "bracketSpacing": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -750,6 +750,15 @@
         "regexpu-core": "^4.5.4"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.6.0.tgz",
+      "integrity": "sha512-q5BZJI0n/B10VaQQvln1IlDK3BTBJFbADx7tv+oXDPIDZuTo37H5Adb9jhlXm/fEN4Y7/64qD9mnrJJG7rmaTw==",
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/preset-env": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.0.tgz",
@@ -1899,6 +1908,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "core-js": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
     },
     "core-js-compat": {
       "version": "3.2.1",
@@ -4229,6 +4243,11 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "@skpm/builder": "^0.7.4",
     "prettier": "^1.14.2"
   },
-  "author": "Monzo <harry@monzo.com>"
+  "author": "Monzo <harry@monzo.com>",
+  "dependencies": {
+    "@babel/polyfill": "^7.6.0"
+  }
 }

--- a/src/artboards.js
+++ b/src/artboards.js
@@ -1,5 +1,5 @@
-import { getMasterPage } from "./utils";
-import { validateAll } from "./validators";
+import {getMasterPage} from './utils';
+import {validateAll} from './validators';
 
 export function artboardsByName(page) {
   const artboards = page.artboards();
@@ -49,7 +49,7 @@ export function artboardRowsByPosition(page) {
   }
   const yPositions = Object.entries(rows).map(([name, row]) => [
     name,
-    row[0].frame().y()
+    row[0].frame().y(),
   ]);
 
   // Add other artboards into the rows

--- a/src/cmd/validate-and-fix.js
+++ b/src/cmd/validate-and-fix.js
@@ -1,8 +1,8 @@
-import UI from "sketch/ui";
-import { getMasterPage } from "../utils";
-import { validateAll } from "../validators";
-import { autoAlignArtboards } from "../artboards";
-import { markWipRows } from "../wip-rows";
+import UI from 'sketch/ui';
+import {getMasterPage} from '../utils';
+import {validateAll} from '../validators';
+import {autoAlignArtboards} from '../artboards';
+import {markWipRows} from '../wip-rows';
 
 export default function validateAndFix(context) {
   const result = validateAll(context);

--- a/src/cmd/validate-and-fix.js
+++ b/src/cmd/validate-and-fix.js
@@ -1,21 +1,21 @@
 import UI from 'sketch/ui';
-import {getMasterPage} from '../utils';
+import {getPageByName} from '../utils';
 import {validateAll} from '../validators';
 import {autoAlignArtboards} from '../artboards';
 import {markWipRows} from '../wip-rows';
+import {REQUIRED_PAGE_NAMES} from '../constants';
 
 export default async function validateAndFix(context) {
   try {
     await validateAll(context);
   } catch (error) {
-    UI.message(`‼️ ${erro.message}`);
+    UI.message(`‼️ ${error.message}`);
   }
 
-  const master = getPageByName(context, 'Master');
+  REQUIRED_PAGE_NAMES.forEach(pageName => {
+    const page = getPageByName(context, pageName);
 
-  // Fix artboard alignment on the Master page
-  autoAlignArtboards(master);
-
-  // Colour the backgrounds of rows with WIP symbols
-  markWipRows(context, master);
+    // Fix artboard alignment on the page
+    autoAlignArtboards(page);
+  });
 }

--- a/src/cmd/validate-and-fix.js
+++ b/src/cmd/validate-and-fix.js
@@ -4,14 +4,14 @@ import {validateAll} from '../validators';
 import {autoAlignArtboards} from '../artboards';
 import {markWipRows} from '../wip-rows';
 
-export default function validateAndFix(context) {
-  const result = validateAll(context);
-  if (!result.success) {
-    UI.message(`‼️ ${result.message}`);
-    return;
+export default async function validateAndFix(context) {
+  try {
+    await validateAll(context);
+  } catch (error) {
+    UI.message(`‼️ ${erro.message}`);
   }
 
-  const master = getMasterPage(context);
+  const master = getPageByName(context, 'Master');
 
   // Fix artboard alignment on the Master page
   autoAlignArtboards(master);

--- a/src/cmd/validate.js
+++ b/src/cmd/validate.js
@@ -1,5 +1,5 @@
-import UI from "sketch/ui";
-import { validateAll } from "../validators";
+import UI from 'sketch/ui';
+import {validateAll} from '../validators';
 
 export default function validate(context, hideSuccess) {
   const result = validateAll(context);

--- a/src/cmd/validate.js
+++ b/src/cmd/validate.js
@@ -1,11 +1,11 @@
 import UI from 'sketch/ui';
 import {validateAll} from '../validators';
 
-export default function validate(context, hideSuccess) {
-  const result = validateAll(context);
-  if (result.success) {
+export default async function validate(context) {
+  try {
+    await validateAll(context);
     UI.message(`😍 Looks good!`);
-  } else {
-    UI.message(`‼️ ${result.message}`);
+  } catch (error) {
+    UI.message(`‼️ ${error.message}`);
   }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,2 @@
+export const REQUIRED_PAGE_NAMES = ['iOS', 'Android'];
+export const ALLOWED_PAGE_NAMES = ['iOS', 'Android', 'Master', 'Symbols'];

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
-export function getMasterPage(context) {
+export function getPageByName(context, name) {
   const pages = context.document.pages();
   for (let i = 0; i < pages.length; i++) {
-    if (pages[i].name() == 'Master') {
+    if (pages[i].name() == name) {
       return pages[i];
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 export function getMasterPage(context) {
   const pages = context.document.pages();
   for (let i = 0; i < pages.length; i++) {
-    if (pages[i].name() == "Master") {
+    if (pages[i].name() == 'Master') {
       return pages[i];
     }
   }

--- a/src/validators.js
+++ b/src/validators.js
@@ -1,62 +1,94 @@
-import {getMasterPage} from './utils';
+import {getPageByName} from './utils';
+
+const REQUIRED_PAGE_NAMES = ['iOS', 'Android'];
+const ALLOWED_PAGE_NAMES = ['iOS', 'Android', 'Master', 'Symbols'];
 
 const validators = [
-  validateMasterPresence,
+  validatePagePresence,
   validatePageNames,
   validateArtboardNames,
 ];
+
 export default validators;
 
 export function validateAll(context) {
-  for (let validator of validators) {
-    const result = validator(context);
-    if (!result.success) {
-      return result;
+  return new Promise(async (resolve, reject) => {
+    for (let validator of validators) {
+      try {
+        await validator(context);
+      } catch (error) {
+        reject(error);
+      }
     }
-  }
-  return {success: true};
+
+    resolve();
+  });
 }
 
-export function validateMasterPresence(context) {
-  if (!getMasterPage(context)) {
-    return {success: false, message: "Missing page 'Master'"};
-  }
-  return {success: true};
+/**
+ * Ensures that there is either a Master page, or an iOS/Android page.
+ */
+export function validatePagePresence(context) {
+  return new Promise((resolve, reject) => {
+    REQUIRED_PAGE_NAMES.forEach(pageName => {
+      if (!getPageByName(context, pageName)) {
+        reject({message: `Missing page ${pageName}`});
+      }
+    });
+
+    resolve();
+  });
 }
 
 export function validatePageNames(context) {
-  const allowedNames = ['Master', 'Symbols'];
-  const pages = context.document.pages();
-  for (let i = 0; i < pages.length; i++) {
-    const name = String(pages[i].name());
-    if (allowedNames.indexOf(name) === -1) {
-      return {success: false, message: `Invalid page name '${name}'`};
+  return new Promise((resolve, reject) => {
+    const allowedNames = ['Master', 'Symbols', 'iOS', 'Android'];
+    const pages = context.document.pages();
+
+    for (let i = 0; i < pages.length; i++) {
+      const name = String(pages[i].name());
+
+      if (allowedNames.indexOf(name) === -1) {
+        reject({message: `Invalid page name '${name}'`});
+      }
     }
-  }
-  return {success: true};
+
+    resolve();
+  });
 }
 
 export function validateArtboardNames(context) {
-  const master = getMasterPage(context);
-  const artboards = master.artboards();
-  const artboardsByName = {};
-  let flowStart = false;
-  for (let i = 0; i < artboards.length; i++) {
-    const name = String(artboards[i].name());
-    if (name.match(/[0]{2}$/)) {
-      flowStart = true;
-    }
-    if (artboardsByName[name]) {
-      return {success: false, message: `Duplicate artboard name '${name}'`};
-    }
-    artboardsByName[name] = name;
+  return new Promise((resolve, reject) => {
+    const pages = context.document.pages();
 
-    if (!name.match(/^\d{3,4}(\.[A-Z]{1,2})?/)) {
-      return {success: false, message: `Invalid artboard name '${name}'`};
-    }
-  }
-  if (!flowStart) {
-    return {success: false, message: `Missing x00 artboard to start the flow`};
-  }
-  return {success: true};
+    pages.forEach(page => {
+      const artboards = page.artboards();
+      const artboardsByName = {};
+
+      let flowStart = false;
+
+      artboards.forEach(artboard => {
+        const name = String(artboard.name());
+
+        if (name.match(/[0]{2}$/)) {
+          flowStart = true;
+        }
+
+        if (artboardsByName[name]) {
+          reject({message: `Duplicate artboard name '${name}'`});
+        }
+
+        artboardsByName[name] = name;
+
+        if (!name.match(/^\d{3,4}(\.[A-Z]{1,2})?/)) {
+          reject({message: `Invalid artboard name '${name}'`});
+        }
+      });
+
+      if (!flowStart) {
+        reject({message: `Missing x00 artboard to start the flow`});
+      }
+    });
+    resolve();
+  });
 }

--- a/src/validators.js
+++ b/src/validators.js
@@ -1,9 +1,9 @@
-import { getMasterPage } from "./utils";
+import {getMasterPage} from './utils';
 
 const validators = [
   validateMasterPresence,
   validatePageNames,
-  validateArtboardNames
+  validateArtboardNames,
 ];
 export default validators;
 
@@ -14,26 +14,26 @@ export function validateAll(context) {
       return result;
     }
   }
-  return { success: true };
+  return {success: true};
 }
 
 export function validateMasterPresence(context) {
   if (!getMasterPage(context)) {
-    return { success: false, message: "Missing page 'Master'" };
+    return {success: false, message: "Missing page 'Master'"};
   }
-  return { success: true };
+  return {success: true};
 }
 
 export function validatePageNames(context) {
-  const allowedNames = ["Master", "Symbols"];
+  const allowedNames = ['Master', 'Symbols'];
   const pages = context.document.pages();
   for (let i = 0; i < pages.length; i++) {
     const name = String(pages[i].name());
     if (allowedNames.indexOf(name) === -1) {
-      return { success: false, message: `Invalid page name '${name}'` };
+      return {success: false, message: `Invalid page name '${name}'`};
     }
   }
-  return { success: true };
+  return {success: true};
 }
 
 export function validateArtboardNames(context) {
@@ -47,16 +47,16 @@ export function validateArtboardNames(context) {
       flowStart = true;
     }
     if (artboardsByName[name]) {
-      return { success: false, message: `Duplicate artboard name '${name}'` };
+      return {success: false, message: `Duplicate artboard name '${name}'`};
     }
     artboardsByName[name] = name;
 
     if (!name.match(/^\d{3,4}(\.[A-Z]{1,2})?/)) {
-      return { success: false, message: `Invalid artboard name '${name}'` };
+      return {success: false, message: `Invalid artboard name '${name}'`};
     }
   }
   if (!flowStart) {
-    return { success: false, message: `Missing x00 artboard to start the flow` };
+    return {success: false, message: `Missing x00 artboard to start the flow`};
   }
-  return { success: true };
+  return {success: true};
 }

--- a/src/validators.js
+++ b/src/validators.js
@@ -1,7 +1,5 @@
 import {getPageByName} from './utils';
-
-const REQUIRED_PAGE_NAMES = ['iOS', 'Android'];
-const ALLOWED_PAGE_NAMES = ['iOS', 'Android', 'Master', 'Symbols'];
+import {REQUIRED_PAGE_NAMES, ALLOWED_PAGE_NAMES} from './constants';
 
 const validators = [
   validatePagePresence,

--- a/src/wip-rows.js
+++ b/src/wip-rows.js
@@ -1,10 +1,10 @@
-import { Document } from "sketch/dom";
-import { artboardRowsByName } from "./artboards";
-import { colorFromString } from "./utils";
+import {Document} from 'sketch/dom';
+import {artboardRowsByName} from './artboards';
+import {colorFromString} from './utils';
 
 const wipSymbolRegex = /\bWIP$/;
-const defaultArtboardColor = colorFromString("#000000");
-const wipArtboardColor = colorFromString("#F43951");
+const defaultArtboardColor = colorFromString('#000000');
+const wipArtboardColor = colorFromString('#F43951');
 
 export function markWipRows(context, page) {
   const wipRows = findWipRows(context, page);
@@ -35,7 +35,7 @@ export function findWipRows(context, page) {
 
   const wipRows = [];
   for (let instance of symbolMaster.getAllInstances()) {
-    while (instance && instance.type != "Artboard") {
+    while (instance && instance.type != 'Artboard') {
       instance = instance.parent;
     }
 

--- a/src/wip-rows.js
+++ b/src/wip-rows.js
@@ -34,6 +34,7 @@ export function findWipRows(context, page) {
   }
 
   const wipRows = [];
+
   for (let instance of symbolMaster.getAllInstances()) {
     while (instance && instance.type != 'Artboard') {
       instance = instance.parent;

--- a/webpack.skpm.config.js
+++ b/webpack.skpm.config.js
@@ -1,0 +1,3 @@
+module.exports = config => {
+  config.entry = ['@babel/polyfill', config.entry]; // eslint-disable-line no-param-reassign
+};


### PR DESCRIPTION
In Q4, we'll be moving towards a new file structure for mobile.

The main change here is to combine iOS and Android designs in to the same file. This should encourage designers to think about both experiences, and will make it easier to compare cross-platform flows.

This PR updates the pages that are checked from `Master` to `iOS/Android`.

Other code health changes:
- We had the prettier npm package installed, but no config. We now have one.
- Introduced Promises and reject/resolve rather than rolling our our return/error/message system.