### PR TITLE
Allow mobile and master rules to work together

### DIFF
--- a/src/cmd/validate-and-fix.js
+++ b/src/cmd/validate-and-fix.js
@@ -3,7 +3,7 @@ import {getPageByName} from '../utils';
 import {validateAll} from '../validators';
 import {autoAlignArtboards} from '../artboards';
 import {markWipRows} from '../wip-rows';
-import {REQUIRED_PAGE_NAMES} from '../constants';
+import {SCOPED_PAGE_NAMES} from '../constants';
 
 export default async function validateAndFix(context) {
   try {
@@ -12,7 +12,7 @@ export default async function validateAndFix(context) {
     UI.message(`‼️ ${error.message}`);
   }
 
-  REQUIRED_PAGE_NAMES.forEach(pageName => {
+  SCOPED_PAGE_NAMES.forEach(pageName => {
     const page = getPageByName(context, pageName);
 
     // Fix artboard alignment on the page

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,2 +1,2 @@
-export const REQUIRED_PAGE_NAMES = ['iOS', 'Android'];
+export const SCOPED_PAGE_NAMES = ['iOS', 'Android', 'Master'];
 export const ALLOWED_PAGE_NAMES = ['iOS', 'Android', 'Master', 'Symbols'];

--- a/src/validators.js
+++ b/src/validators.js
@@ -1,5 +1,5 @@
 import {getPageByName} from './utils';
-import {REQUIRED_PAGE_NAMES, ALLOWED_PAGE_NAMES} from './constants';
+import {ALLOWED_PAGE_NAMES} from './constants';
 
 const validators = [
   validatePagePresence,
@@ -24,15 +24,24 @@ export function validateAll(context) {
 }
 
 /**
- * Ensures that there is either a Master page, or an iOS/Android page.
+ * Ensures that there is either a Master page, or that both iOS and Android exist
  */
 export function validatePagePresence(context) {
   return new Promise((resolve, reject) => {
-    REQUIRED_PAGE_NAMES.forEach(pageName => {
-      if (!getPageByName(context, pageName)) {
-        reject({message: `Missing page ${pageName}`});
-      }
-    });
+    if (getPageByName(context, 'iOS') && !getPageByName(context, 'Android')) {
+      reject({message: `Missing page Android`});
+    }
+
+    if (getPageByName(context, 'Android') && !getPageByName(context, 'iOS')) {
+      reject({message: `Missing page iOS`});
+    }
+
+    if (
+      !getPageByName(context, 'Master') &&
+      (!getPageByName(context, 'iOS') || !getPageByName(context, 'Android'))
+    ) {
+      reject({message: `Missing page Master`});
+    }
 
     resolve();
   });


### PR DESCRIPTION
This PR updates the page presence rules to support both the new rules (`iOS` and `Android`) and the old rule (`Master`).

- An `iOS` page along with no `Android` page will fail validation.
- A `Master` page on its own will pass.
- An `iOS` and `Android` page will pass.
