### PR TITLE
Allow Preview to be used as a page name

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,2 +1,8 @@
 export const SCOPED_PAGE_NAMES = ['iOS', 'Android', 'Master'];
-export const ALLOWED_PAGE_NAMES = ['iOS', 'Android', 'Master', 'Symbols'];
+export const ALLOWED_PAGE_NAMES = [
+  'iOS',
+  'Android',
+  'Master',
+  'Symbols',
+  'Preview',
+];

--- a/src/validators.js
+++ b/src/validators.js
@@ -49,13 +49,12 @@ export function validatePagePresence(context) {
 
 export function validatePageNames(context) {
   return new Promise((resolve, reject) => {
-    const allowedNames = ['Master', 'Symbols', 'iOS', 'Android'];
     const pages = context.document.pages();
 
     for (let i = 0; i < pages.length; i++) {
       const name = String(pages[i].name());
 
-      if (allowedNames.indexOf(name) === -1) {
+      if (ALLOWED_PAGE_NAMES.indexOf(name) === -1) {
         reject({message: `Invalid page name '${name}'`});
       }
     }


### PR DESCRIPTION
The `Preview` page is used to display a preview of the file in Sketch Cloud.

This PR adds it to the allowed page names array.